### PR TITLE
Ensuring optimal space for `transpile_jcz_cf`

### DIFF
--- a/graphix_jcz_transpiler/jcz_transpiler.py
+++ b/graphix_jcz_transpiler/jcz_transpiler.py
@@ -21,6 +21,7 @@ from graphix.fundamentals import ANGLE_PI, ParameterizedAngle
 from graphix.instruction import InstructionKind
 from graphix.measurements import BlochMeasurement, Measurement, PauliMeasurement
 from graphix.opengraph import OpenGraph
+from graphix.optimization import StandardizedPattern
 from graphix.transpiler import (
     Circuit,
     TranspileResult,
@@ -514,6 +515,6 @@ def transpile_jcz_cf(circuit: Circuit) -> TranspileResult:
 
     """
     f, classical_outputs = circuit_to_causal_flow(circuit)
-    pattern = f.to_corrections().to_pattern()
+    pattern = StandardizedPattern.from_pattern(f.to_corrections().to_pattern()).to_space_optimal_pattern()
     pattern.extend(classical_outputs.values())
     return TranspileResult(pattern, tuple(classical_outputs.keys()))

--- a/graphix_jcz_transpiler/jcz_transpiler.py
+++ b/graphix_jcz_transpiler/jcz_transpiler.py
@@ -437,7 +437,7 @@ def circuit_to_causal_flow(
 
     Returns
     -------
-        a causal flow.
+        a causal flow, classical outputs, and output nodes.
 
     Raises
     ------
@@ -488,8 +488,8 @@ def circuit_to_causal_flow(
     outputs.extend(classical_outputs.keys())
     og = OpenGraph(
         graph=graph,
-        input_nodes=tuple(inputs),
-        output_nodes=tuple(outputs),
+        input_nodes=inputs,
+        output_nodes=outputs,
         measurements=measurements,
     )
     z_corrections: dict[int, AbstractSet[int]] = {}

--- a/tests/test_jcz_transpiler.py
+++ b/tests/test_jcz_transpiler.py
@@ -165,28 +165,21 @@ def test_random_circuit_compare(fx_bg: PCG64, jumps: int) -> None:
     circuit = rand_circuit(nqubits, depth, rng, use_ccx=True)
     pattern = transpile_jcz(circuit).pattern.infer_pauli_measurements()
     pattern.remove_input_nodes()
+    pattern = pattern.infer_pauli_measurements()
     pattern.perform_pauli_measurements()
     pattern_og = transpile_jcz_cf(circuit).pattern.infer_pauli_measurements()
     pattern_og.remove_input_nodes()
+    pattern_og = pattern_og.infer_pauli_measurements()
     pattern_og.perform_pauli_measurements()
     pattern_gpx = circuit.transpile().pattern.infer_pauli_measurements()
     pattern_gpx.remove_input_nodes()
+    pattern_gpx = pattern_gpx.infer_pauli_measurements()
     pattern_gpx.perform_pauli_measurements()
-    state = pattern.simulate_pattern(backend="tensornetwork", branch_selector=bs)
-    state_og = pattern_og.simulate_pattern(backend="tensornetwork", branch_selector=bs)
-    state_gpx = pattern_gpx.simulate_pattern(backend="tensornetwork", branch_selector=bs)
-    assert np.abs(
-        np.dot(
-            state.to_statevector().flatten().conjugate(),
-            state_og.to_statevector().flatten(),
-        )
-    ) == pytest.approx(1)
-    assert np.abs(
-        np.dot(
-            state_og.to_statevector().flatten().conjugate(),
-            state_gpx.to_statevector().flatten(),
-        )
-    ) == pytest.approx(1)
+    state = pattern.simulate_pattern(branch_selector=bs)
+    state_og = pattern_og.simulate_pattern(branch_selector=bs)
+    state_gpx = pattern_gpx.simulate_pattern(branch_selector=bs)
+    assert state.isclose(state_og)
+    assert state_og.isclose(state_gpx)
 
 
 @pytest.mark.parametrize("jumps", range(1, 11))

--- a/tests/test_jcz_transpiler.py
+++ b/tests/test_jcz_transpiler.py
@@ -14,10 +14,11 @@ from graphix.branch_selector import ConstBranchSelector
 from graphix.fundamentals import ANGLE_PI, Axis
 from graphix.instruction import CCX, CNOT, CZ
 from graphix.measurements import BlochMeasurement, Measurement
+from graphix.optimization import StandardizedPattern
 from graphix.random_objects import rand_circuit
 from graphix.sim.statevec import Statevec
 from graphix.simulator import DefaultMeasureMethod
-from graphix.transpiler import Circuit
+from graphix.transpiler import Circuit, transpile_swaps
 from numpy.random import PCG64, Generator
 
 from graphix_jcz_transpiler import (
@@ -162,24 +163,31 @@ def test_random_circuit_compare(fx_bg: PCG64, jumps: int) -> None:
     rng = Generator(fx_bg.jumped(jumps))
     nqubits = 3
     depth = 2
-    circuit = rand_circuit(nqubits, depth, rng, use_ccx=True)
-    pattern = transpile_jcz(circuit).pattern.infer_pauli_measurements()
-    pattern.remove_input_nodes()
-    pattern = pattern.infer_pauli_measurements()
-    pattern.perform_pauli_measurements()
-    pattern_og = transpile_jcz_cf(circuit).pattern.infer_pauli_measurements()
-    pattern_og.remove_input_nodes()
-    pattern_og = pattern_og.infer_pauli_measurements()
-    pattern_og.perform_pauli_measurements()
-    pattern_gpx = circuit.transpile().pattern.infer_pauli_measurements()
-    pattern_gpx.remove_input_nodes()
-    pattern_gpx = pattern_gpx.infer_pauli_measurements()
-    pattern_gpx.perform_pauli_measurements()
-    state = pattern.simulate_pattern(branch_selector=bs)
-    state_og = pattern_og.simulate_pattern(branch_selector=bs)
-    state_gpx = pattern_gpx.simulate_pattern(branch_selector=bs)
-    assert state.isclose(state_og)
-    assert state_og.isclose(state_gpx)
+    base_circuit = rand_circuit(nqubits, depth, rng, use_ccx=True)
+    base_circuit = transpile_swaps(base_circuit).circuit
+    for k in range(len(base_circuit.instruction) + 1):
+        circuit = Circuit(nqubits, base_circuit.instruction[:k])
+        print("Added gate", k, ":", circuit.instruction[-1] if circuit.instruction else "None")
+        pattern = transpile_jcz(circuit).pattern.infer_pauli_measurements()
+        pattern.remove_input_nodes()
+        pattern = pattern.infer_pauli_measurements()
+        pattern.perform_pauli_measurements()
+        pattern = StandardizedPattern.from_pattern(pattern).to_space_optimal_pattern()
+        pattern_og = transpile_jcz_cf(circuit).pattern.infer_pauli_measurements()
+        pattern_og.remove_input_nodes()
+        pattern_og = pattern_og.infer_pauli_measurements()
+        pattern_og.perform_pauli_measurements()
+        pattern_og = StandardizedPattern.from_pattern(pattern_og).to_space_optimal_pattern()
+        pattern_gpx = circuit.transpile().pattern.infer_pauli_measurements()
+        pattern_gpx.remove_input_nodes()
+        pattern_gpx = pattern_gpx.infer_pauli_measurements()
+        pattern_gpx.perform_pauli_measurements()
+        pattern_gpx = StandardizedPattern.from_pattern(pattern_gpx).to_space_optimal_pattern()
+        state = pattern.simulate_pattern(branch_selector=bs)
+        state_og = pattern_og.simulate_pattern(branch_selector=bs)
+        state_gpx = pattern_gpx.simulate_pattern(branch_selector=bs)
+        assert state.isclose(state_og)
+        assert state_og.isclose(state_gpx)
 
 
 @pytest.mark.parametrize("jumps", range(1, 11))
@@ -191,15 +199,19 @@ def test_random_circuit_with_m(fx_bg: PCG64, jumps: int) -> None:
     depth = 2
     circuit = rand_circuit(nqubits, depth, rng, use_ccx=True)
     circuit.m(1, Axis.Y)
+    circuit = transpile_swaps(circuit).circuit
     pattern = transpile_jcz(circuit).pattern.infer_pauli_measurements()
     pattern.remove_input_nodes()
     pattern.perform_pauli_measurements()
+    pattern = StandardizedPattern.from_pattern(pattern).to_space_optimal_pattern()
     pattern_og = transpile_jcz_cf(circuit).pattern.infer_pauli_measurements()
     pattern_og.remove_input_nodes()
     pattern_og.perform_pauli_measurements()
+    pattern_og = StandardizedPattern.from_pattern(pattern_og).to_space_optimal_pattern()
     pattern_gpx = circuit.transpile().pattern.infer_pauli_measurements()
     pattern_gpx.remove_input_nodes()
     pattern_gpx.perform_pauli_measurements()
+    pattern_gpx = StandardizedPattern.from_pattern(pattern_gpx).to_space_optimal_pattern()
     state = pattern.simulate_pattern(backend="tensornetwork", branch_selector=bs)
     state_og = pattern_og.simulate_pattern(backend="tensornetwork", branch_selector=bs)
     state_gpx = pattern_gpx.simulate_pattern(backend="tensornetwork", branch_selector=bs)

--- a/tests/test_jcz_transpiler.py
+++ b/tests/test_jcz_transpiler.py
@@ -147,6 +147,9 @@ def test_circuit_simulation_compare_graphix(circuit: Circuit) -> None:
     bs = ConstBranchSelector(0)
     pattern = circuit.transpile().pattern.infer_pauli_measurements()
     pattern_cf = transpile_jcz_cf(circuit).pattern.infer_pauli_measurements()
+    pattern_jcz = transpile_jcz(circuit).pattern.infer_pauli_measurements()
+    pattern_jcz.remove_input_nodes()
+    pattern_jcz.perform_pauli_measurements()
     pattern.remove_input_nodes()
     pattern.perform_pauli_measurements()
     pattern_cf.remove_input_nodes()
@@ -163,30 +166,25 @@ def test_random_circuit_compare(fx_bg: PCG64, jumps: int) -> None:
     rng = Generator(fx_bg.jumped(jumps))
     nqubits = 3
     depth = 2
-    base_circuit = rand_circuit(nqubits, depth, rng, use_ccx=True)
-    base_circuit = transpile_swaps(base_circuit).circuit
-    for k in range(len(base_circuit.instruction) + 1):
-        circuit = Circuit(nqubits, base_circuit.instruction[:k])
-        pattern = transpile_jcz(circuit).pattern.infer_pauli_measurements()
-        pattern.remove_input_nodes()
-        pattern.perform_pauli_measurements()
-        pattern = StandardizedPattern.from_pattern(pattern).to_space_optimal_pattern()
-        pattern_og = transpile_jcz_cf(circuit).pattern.infer_pauli_measurements()
-        pattern_og.remove_input_nodes()
-        pattern_og.perform_pauli_measurements()
-        pattern_og = StandardizedPattern.from_pattern(pattern_og).to_space_optimal_pattern()
-        pattern_gpx = circuit.transpile().pattern.infer_pauli_measurements()
-        pattern_gpx.remove_input_nodes()
-        pattern_gpx.perform_pauli_measurements()
-        pattern_gpx = StandardizedPattern.from_pattern(pattern_gpx).to_space_optimal_pattern()
-        state = pattern.simulate_pattern(branch_selector=bs)
-        state_og = pattern_og.simulate_pattern(branch_selector=bs)
-        state_gpx = pattern_gpx.simulate_pattern(branch_selector=bs)
-        # assert state.isclose(state_og)
-        if not state.isclose(state_og):
-            pytest.fail("Circuit instruction " + str(k) + ": " + str(circuit.instruction[-1]))
-        if not state_og.isclose(state_gpx):
-            pytest.fail("Circuit instruction " + str(k) + ": " + str(circuit.instruction[-1]))
+    circuit = rand_circuit(nqubits, depth, rng, use_ccx=True)
+    circuit = transpile_swaps(circuit).circuit
+    pattern = transpile_jcz(circuit).pattern
+    pattern.remove_input_nodes()
+    pattern.perform_pauli_measurements()
+    pattern = StandardizedPattern.from_pattern(pattern).to_space_optimal_pattern()
+    pattern_og = transpile_jcz_cf(circuit).pattern
+    pattern_og.remove_input_nodes()
+    pattern_og.perform_pauli_measurements()
+    pattern_og = StandardizedPattern.from_pattern(pattern_og).to_space_optimal_pattern()
+    pattern_gpx = circuit.transpile().pattern
+    pattern_gpx.remove_input_nodes()
+    pattern_gpx.perform_pauli_measurements()
+    pattern_gpx = StandardizedPattern.from_pattern(pattern_gpx).to_space_optimal_pattern()
+    state = pattern.simulate_pattern(branch_selector=bs)
+    state_og = pattern_og.simulate_pattern(branch_selector=bs)
+    state_gpx = pattern_gpx.simulate_pattern(branch_selector=bs)
+    assert state.isclose(state_og)
+    assert state_og.isclose(state_gpx)
 
 
 @pytest.mark.parametrize("jumps", range(1, 11))

--- a/tests/test_jcz_transpiler.py
+++ b/tests/test_jcz_transpiler.py
@@ -168,15 +168,15 @@ def test_random_circuit_compare(fx_bg: PCG64, jumps: int) -> None:
     depth = 2
     circuit = rand_circuit(nqubits, depth, rng, use_ccx=True)
     circuit = transpile_swaps(circuit).circuit
-    pattern = transpile_jcz(circuit).pattern
+    pattern = transpile_jcz(circuit).pattern.infer_pauli_measurements()
     pattern.remove_input_nodes()
     pattern.perform_pauli_measurements()
     pattern = StandardizedPattern.from_pattern(pattern).to_space_optimal_pattern()
-    pattern_og = transpile_jcz_cf(circuit).pattern
+    pattern_og = transpile_jcz_cf(circuit).pattern.infer_pauli_measurements()
     pattern_og.remove_input_nodes()
     pattern_og.perform_pauli_measurements()
     pattern_og = StandardizedPattern.from_pattern(pattern_og).to_space_optimal_pattern()
-    pattern_gpx = circuit.transpile().pattern
+    pattern_gpx = circuit.transpile().pattern.infer_pauli_measurements()
     pattern_gpx.remove_input_nodes()
     pattern_gpx.perform_pauli_measurements()
     pattern_gpx = StandardizedPattern.from_pattern(pattern_gpx).to_space_optimal_pattern()

--- a/tests/test_jcz_transpiler.py
+++ b/tests/test_jcz_transpiler.py
@@ -167,27 +167,26 @@ def test_random_circuit_compare(fx_bg: PCG64, jumps: int) -> None:
     base_circuit = transpile_swaps(base_circuit).circuit
     for k in range(len(base_circuit.instruction) + 1):
         circuit = Circuit(nqubits, base_circuit.instruction[:k])
-        print("Added gate", k, ":", circuit.instruction[-1] if circuit.instruction else "None")
         pattern = transpile_jcz(circuit).pattern.infer_pauli_measurements()
         pattern.remove_input_nodes()
-        pattern = pattern.infer_pauli_measurements()
         pattern.perform_pauli_measurements()
         pattern = StandardizedPattern.from_pattern(pattern).to_space_optimal_pattern()
         pattern_og = transpile_jcz_cf(circuit).pattern.infer_pauli_measurements()
         pattern_og.remove_input_nodes()
-        pattern_og = pattern_og.infer_pauli_measurements()
         pattern_og.perform_pauli_measurements()
         pattern_og = StandardizedPattern.from_pattern(pattern_og).to_space_optimal_pattern()
         pattern_gpx = circuit.transpile().pattern.infer_pauli_measurements()
         pattern_gpx.remove_input_nodes()
-        pattern_gpx = pattern_gpx.infer_pauli_measurements()
         pattern_gpx.perform_pauli_measurements()
         pattern_gpx = StandardizedPattern.from_pattern(pattern_gpx).to_space_optimal_pattern()
         state = pattern.simulate_pattern(branch_selector=bs)
         state_og = pattern_og.simulate_pattern(branch_selector=bs)
         state_gpx = pattern_gpx.simulate_pattern(branch_selector=bs)
-        assert state.isclose(state_og)
-        assert state_og.isclose(state_gpx)
+        # assert state.isclose(state_og)
+        if not state.isclose(state_og):
+            pytest.fail("Circuit instruction " + str(k) + ": " + str(circuit.instruction[-1]))
+        if not state_og.isclose(state_gpx):
+            pytest.fail("Circuit instruction " + str(k) + ": " + str(circuit.instruction[-1]))
 
 
 @pytest.mark.parametrize("jumps", range(1, 11))


### PR DESCRIPTION
Minor PR that ensures `transpile_jcz_cf` produces a pattern with optimal space by default.
Performance is as per Issue #5.